### PR TITLE
Fix for a build-break in AMQP

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -552,7 +552,7 @@ static void *camqp_subscribe_thread (void *user_data) /* {{{ */
         {
             ERROR ("amqp plugin: camqp_connect failed. "
                     "Will sleep for %.3f seconds.",
-                    CDTIME_T_TO_DOUBLE (interval_g))
+                    CDTIME_T_TO_DOUBLE (interval_g));
             sleep (interval_g);
             continue;
         }
@@ -562,7 +562,7 @@ static void *camqp_subscribe_thread (void *user_data) /* {{{ */
         {
             ERROR ("amqp plugin: amqp_simple_wait_frame failed. "
                     "Will sleep for %.3f seconds.",
-                    CDTIME_T_TO_DOUBLE (interval_g))
+                    CDTIME_T_TO_DOUBLE (interval_g));
             camqp_close_connection (conf);
             sleep (interval_g);
             continue;


### PR DESCRIPTION
It seems that some semicolons were left out and broke the build.
