### PR TITLE
fix the irq plugin.

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -380,9 +380,9 @@
 #</Plugin>
 
 #<Plugin irq>
-#	Irq 7
-#	Irq 8
-#	Irq 9
+#	Irq "7"
+#	Irq "8"
+#	Irq "9"
 #	IgnoreSelected true
 #</Plugin>
 

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -1566,7 +1566,7 @@ comment or the number.
 
 =over 4
 
-=item B<Irq> I<Irq>
+=item B<Irq> I"<Irq>"
 
 Select this irq. By default these irqs will then be collected. For a more
 detailed description see B<IgnoreSelected> below.

--- a/src/irq.c
+++ b/src/irq.c
@@ -24,6 +24,7 @@
 #include "common.h"
 #include "plugin.h"
 #include "configfile.h"
+#include "utils_ignorelist.h"
 
 #if !KERNEL_LINUX
 # error "No applicable input method."
@@ -41,54 +42,25 @@ static const char *config_keys[] =
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
-static unsigned int *irq_list;
-static unsigned int irq_list_num;
-
-/* 
- * irq_list_action:
- * 0 => default is to collect selected irqs
- * 1 => ignore selcted irqs
- */
-static int irq_list_action;
+static ignorelist_t *ignorelist = NULL;
 
 static int irq_config (const char *key, const char *value)
 {
-	if (strcasecmp (key, "Irq") == 0)
+	if (ignorelist == NULL)
+		ignorelist = ignorelist_create (/* invert = */ 1);
+	if (ignorelist == NULL)
+		return (1);
+
+	if (strcasecmp ("Irq", key) == 0)
 	{
-		unsigned int *temp;
-		unsigned int irq;
-		char *endptr;
-
-		temp = (unsigned int *) realloc (irq_list, (irq_list_num + 1) * sizeof (unsigned int *));
-		if (temp == NULL)
-		{
-			fprintf (stderr, "irq plugin: Cannot allocate more memory.\n");
-			ERROR ("irq plugin: Cannot allocate more memory.");
-			return (1);
-		}
-		irq_list = temp;
-
-		/* Clear errno, because we need it to see if an error occured. */
-		errno = 0;
-
-		irq = strtol(value, &endptr, 10);
-		if ((endptr == value) || (errno != 0))
-		{
-			fprintf (stderr, "irq plugin: Irq value is not a "
-					"number: `%s'\n", value);
-			ERROR ("irq plugin: Irq value is not a "
-					"number: `%s'", value);
-			return (1);
-		}
-		irq_list[irq_list_num] = irq;
-		irq_list_num++;
+		ignorelist_add (ignorelist, value);
 	}
-	else if (strcasecmp (key, "IgnoreSelected") == 0)
+	else if (strcasecmp ("IgnoreSelected", key) == 0)
 	{
+		int invert = 1;
 		if (IS_TRUE (value))
-			irq_list_action = 1;
-		else
-			irq_list_action = 0;
+			invert = 0;
+		ignorelist_set_invert (ignorelist, invert);
 	}
 	else
 	{
@@ -97,34 +69,15 @@ static int irq_config (const char *key, const char *value)
 	return (0);
 }
 
-/*
- * Check if this interface/instance should be ignored. This is called from
- * both, `submit' and `write' to give client and server the ability to
- * ignore certain stuff..
- */
-static int check_ignore_irq (const unsigned int irq)
-{
-	int i;
-
-	if (irq_list_num < 1)
-		return (0);
-
-	for (i = 0; (unsigned int)i < irq_list_num; i++)
-		if (irq == irq_list[i])
-			return (irq_list_action);
-
-	return (1 - irq_list_action);
-}
-
-static void irq_submit (unsigned int irq, derive_t value)
+static void irq_submit (const char *irq, derive_t value)
 {
 	value_t values[1];
 	value_list_t vl = VALUE_LIST_INIT;
 	int status;
-/*
-	if (check_ignore_irq (irq))
+
+	if (ignorelist_match (ignorelist, irq) != 0)
 		return;
-*/
+
 	values[0].derive = value;
 
 	vl.values = values;
@@ -132,26 +85,22 @@ static void irq_submit (unsigned int irq, derive_t value)
 	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
 	sstrncpy (vl.plugin, "irq", sizeof (vl.plugin));
 	sstrncpy (vl.type, "irq", sizeof (vl.type));
-
-	status = ssnprintf (vl.type_instance, sizeof (vl.type_instance),
-			"%u", irq);
-	if ((status < 1) || ((unsigned int)status >= sizeof (vl.type_instance)))
-		return;
+	sstrncpy (vl.type_instance, irq, sizeof (vl.type_instance));
 
 	plugin_dispatch_values (&vl);
 } /* void irq_submit */
 
 int irq_parse_value (const char *value, value_t *ret_value)
 {
-  char *endptr = NULL;
-  ret_value->derive = (derive_t) strtoll (value, &endptr, 0);
-  if (value == endptr) {
-    return -1;
-  }
-  else if ((NULL != endptr) && ('\0' != *endptr))
-    WARNING ("parse_value: Ignoring trailing garbage after number: %s.",
-        endptr);
-  return 0;
+	char *endptr = NULL;
+	ret_value->derive = (derive_t) strtoll (value, &endptr, 0);
+	if (value == endptr) {
+		return -1;
+	}
+	else if ((NULL != endptr) && ('\0' != *endptr))
+		WARNING ("parse_value: Ignoring trailing garbage after number: %s.",
+		endptr);
+	return 0;
 } /* int irq_parse_value */
 
 static int irq_read (void)
@@ -170,7 +119,8 @@ static int irq_read (void)
 
 	while (fgets (buffer, BUFSIZE, fh) != NULL)
 	{
-		unsigned int irq;
+		char irq_name[64];
+		int irq_name_len;
 		derive_t irq_value;
 		char *endptr;
 		int i;
@@ -183,10 +133,14 @@ static int irq_read (void)
 			continue;
 
 		errno = 0;    /* To distinguish success/failure after call */
-		irq = (unsigned int) strtoul (fields[0], &endptr, /* base = */ 10);
+		irq_name_len = ssnprintf (irq_name, sizeof (irq_name), "%s", fields[0]);
+		endptr = &irq_name[irq_name_len-1];
 
 		if ((endptr == fields[0]) || (errno != 0) || (*endptr != ':'))
 			continue;
+
+		/* remove : */
+		*endptr = 0;
 
 		irq_value = 0;
 		for (i = 1; i < fields_num; i++)
@@ -201,8 +155,8 @@ static int irq_read (void)
 
 			irq_value += v.derive;
 		} /* for (i) */
-		
-		irq_submit (irq, irq_value);
+
+		irq_submit (irq_name, irq_value);
 	}
 
 	fclose (fh);


### PR DESCRIPTION
I have made the following changes
- added support the new /proc/interrupts layout.
- allowed collecting of named interrupt groups i.e. NMI, RES, CAL, LCK
