### PR TITLE
Migration: Ensure destination directories exist when moving RRDs

### DIFF
--- a/contrib/migrate-4-5.px
+++ b/contrib/migrate-4-5.px
@@ -183,6 +183,7 @@ sub handle_file # {{{
     && (!$plugin_inst) && ($type_inst))
   {
     my $dir = join ('/', @path);
+    print "mkdir -p \"$dir/$plugin-$type_inst\"\n";
     print "mv \"$path\" \"$dir/$plugin-$type_inst/$type.rrd\"\n";
   }
 } # }}} sub handle_file


### PR DESCRIPTION
If you have not run collectd 5 before, then when type instances
are migrated to plugin instances the destination directories
may not already exist. For example:

```
mv "./test/df/df-mnt-dlna.rrd" "./test/df-mnt-dlna/df.rrd"
```

This one-liner does a mkdir -p of the destination before
attempting to move the file.
