### PR TITLE
Persistant 'OKAY'

### DIFF
--- a/src/collectd-threshold.pod
+++ b/src/collectd-threshold.pod
@@ -154,6 +154,13 @@ This applies to missing values, too: If set to B<true> a notification about a
 missing value is generated once every B<Interval> seconds. If set to B<false>
 only one such notification is generated until the value appears again.
 
+=item B<PersistOK> B<true>|B<false>
+
+Sets how OKAY notifications act. If set to B<true> one notification will be
+generated for each value that is in the acceptable range. If set to B<false>
+(the default) then a notification is only generated if a value is in range but
+the previous value was not.
+
 =item B<Percentage> B<true>|B<false>
 
 If set to B<true>, the minimum and maximum values given are interpreted as


### PR DESCRIPTION
I submitted this before but never got a response, I've rebased it against master to submit again.

This patch adds a 'PersistOK' flag to the threshold code which means that OKAY messages are raised for the whole time that a service is in the okay state, similar to how WARNING and FAILURE will continue to be raised while a service is outside of acceptable bounds.

My use case is this: I have a message queue which I write these notifications to, and a daemon listening on the message queue which inserts the data into Nagios using passive updates. To protect against situations where this daemon fails and I am not aware of the issue, I have a staleness check set on Nagios- if I don't receive an update within 10 minutes something is wrong and it will raise itself as a warning.

With the stock behaviour it's not possible to tell the difference between monitoring not working and all services being fine as only one OKAY is sent, on the transition from WARNING or FAILURE. This patch allows for a constant trickle of OKAY data to update Nagios and stop the freshness check from running.

No default behaviour is changed, the new code path is only active is PersistOK is set to true. A documentation patch is included.
