### PR TITLE
Allow attribute to call operations

### DIFF
--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -318,8 +318,7 @@ class GenericJMXConfValue
       }
       catch (javax.management.AttributeNotFoundException e)
       {
-        value = conn.invoke (objName, key,
-                            /* parameters */ null, /* signature */ null);
+        value = conn.invoke (objName, key, /* args = */ null, /* types = */ null);
       }
     }
     catch (Exception e)


### PR DESCRIPTION
MBeans provide two entities to the outside world:
- Attributes
- Operations

The former is a simple key/value lookup, while the latter
triggers a method call and yields the result.

Operations have signatures, they can be fed an array of
parameters. For now, calls are triggered assuming
there are no parameters. Later a separate keyword
`Operation` can be introduced, taking a list of
`Parameter` directives specifying type and values
to feed to the MBean operation.
