### PR TITLE
free our bson record after the write as not to leak memory

### DIFF
--- a/src/write_mongodb.c
+++ b/src/write_mongodb.c
@@ -92,6 +92,7 @@ static int wm_write (const data_set_t *ds, /* {{{ */
     else
       assert (23 == 42);
   }
+  /* We must finish the record, other wise the insert will fail */
   bson_finish(&record);
 
   pthread_mutex_lock (&node->lock);
@@ -129,6 +130,8 @@ static int wm_write (const data_set_t *ds, /* {{{ */
   }
 
   pthread_mutex_unlock (&node->lock);
+  /* free our resource as not to leak memory */
+  bson_destroy(&record);
 
   return (0);
 } /* }}} int wm_write */


### PR DESCRIPTION
Fixes memory leaks.

==23779== HEAP SUMMARY:
==23779==     in use at exit: 5,432,821 bytes in 41,341 blocks
==23779==   total heap usage: 416,913 allocs, 375,572 frees, 27,796,507 bytes allocated
==23779== 
==23779== 48 bytes in 1 blocks are definitely lost in loss record 49 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x4084BB: cf_read_generic (configfile.c:693)
==23779==    by 0x408E1A: cf_read (configfile.c:930)
==23779==    by 0x405624: main (collectd.c:477)
==23779== 
==23779== 64 bytes in 1 blocks are definitely lost in loss record 55 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x65FB109: fbh_create (utils_fbhash.c:207)
==23779==    by 0x65F79E2: sockent_open (network.c:1977)
==23779==    by 0x65F842A: network_config (network.c:2955)
==23779==    by 0x40903C: cf_read (configfile.c:361)
==23779==    by 0x405624: main (collectd.c:477)
==23779== 
==23779== 128 bytes in 1 blocks are possibly lost in loss record 65 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x40BD65: plugin_dispatch_values_secure (plugin.c:1602)
==23779==    by 0x65FA182: parse_packet (network.c:408)
==23779==    by 0x65F9F48: parse_packet (network.c:1036)
==23779==    by 0x65FA3B0: dispatch_thread (network.c:2224)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 91 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFDE5: interface_read (interface.c:278)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x90986FF: ???
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 92 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x63F2ABE: memory_submit (memory.c:151)
==23779==    by 0x63F2C92: memory_read (memory.c:316)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x9A996FF: ???
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 93 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFE65: interface_read (interface.c:286)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x90986FF: ???
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 94 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x63F2ABE: memory_submit (memory.c:151)
==23779==    by 0x63F2CA8: memory_read (memory.c:317)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x9A996FF: ???
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 95 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x63F2ABE: memory_submit (memory.c:151)
==23779==    by 0x63F2CBE: memory_read (memory.c:318)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x9A996FF: ???
==23779== 
==23779== 4,096 bytes in 32 blocks are definitely lost in loss record 96 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x63F2ABE: memory_submit (memory.c:151)
==23779==    by 0x63F2CD4: memory_read (memory.c:319)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0x9A996FF: ???
==23779== 
==23779== 6,176 bytes in 32 blocks are definitely lost in loss record 97 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E820D9: bson_finish (bson.c:644)
==23779==    by 0x6C77168: wm_write (write_mongodb.c:95)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFE25: interface_read (interface.c:282)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== 6,720 bytes in 32 blocks are definitely lost in loss record 98 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E83A26: bson_append_long (bson.c:670)
==23779==    by 0x6C77116: wm_write (write_mongodb.c:91)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFDE5: interface_read (interface.c:278)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== 6,720 bytes in 32 blocks are definitely lost in loss record 99 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E83A26: bson_append_long (bson.c:670)
==23779==    by 0x6C77116: wm_write (write_mongodb.c:91)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFE25: interface_read (interface.c:282)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== 6,720 bytes in 32 blocks are definitely lost in loss record 100 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E83A26: bson_append_long (bson.c:670)
==23779==    by 0x6C77116: wm_write (write_mongodb.c:91)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x5FEFCC8: if_submit (interface.c:183)
==23779==    by 0x5FEFE65: interface_read (interface.c:286)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== 6,944 bytes in 32 blocks are definitely lost in loss record 101 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E8393E: bson_append_double (bson.c:670)
==23779==    by 0x6C7714E: wm_write (write_mongodb.c:87)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x61F193C: load_read (load.c:67)
==23779==    by 0x40C4E9: plugin_read_thread (plugin.c:431)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779==    by 0xA49A6FF: ???
==23779== 
==23779== 110,460 bytes in 526 blocks are definitely lost in loss record 111 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E83A26: bson_append_long (bson.c:670)
==23779==    by 0x6C77116: wm_write (write_mongodb.c:91)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x40BD65: plugin_dispatch_values_secure (plugin.c:1602)
==23779==    by 0x65FA182: parse_packet (network.c:408)
==23779==    by 0x65F9F48: parse_packet (network.c:1036)
==23779==    by 0x65FA3B0: dispatch_thread (network.c:2224)
==23779== 
==23779== 113,708 bytes in 524 blocks are definitely lost in loss record 112 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E8393E: bson_append_double (bson.c:670)
==23779==    by 0x6C7714E: wm_write (write_mongodb.c:87)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x40BD65: plugin_dispatch_values_secure (plugin.c:1602)
==23779==    by 0x65FA182: parse_packet (network.c:408)
==23779==    by 0x65F9F48: parse_packet (network.c:1036)
==23779==    by 0x65FA3B0: dispatch_thread (network.c:2224)
==23779== 
==23779== 203,229 bytes in 1,053 blocks are definitely lost in loss record 113 of 114
==23779==    at 0x4C2710F: realloc (vg_replace_malloc.c:525)
==23779==    by 0x6E81DFC: bson_realloc (bson.c:926)
==23779==    by 0x6E81FE9: bson_ensure_space (bson.c:627)
==23779==    by 0x6E820D9: bson_finish (bson.c:644)
==23779==    by 0x6C77168: wm_write (write_mongodb.c:95)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x40BD65: plugin_dispatch_values_secure (plugin.c:1602)
==23779==    by 0x65FA182: parse_packet (network.c:408)
==23779==    by 0x65F9F48: parse_packet (network.c:1036)
==23779==    by 0x65FA3B0: dispatch_thread (network.c:2224)
==23779== 
==23779== 4,768,128 (4,767,744 direct, 384 indirect) bytes in 37,248 blocks are definitely lost in loss record 114 of 114
==23779==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==23779==    by 0x6E81E2C: bson_malloc (bson.c:919)
==23779==    by 0x6E81F4D: bson_init (bson.c:574)
==23779==    by 0x6C77071: wm_write (write_mongodb.c:75)
==23779==    by 0x40C174: plugin_write (plugin.c:1248)
==23779==    by 0x4094C4: fc_bit_write_invoke (filter_chain.c:698)
==23779==    by 0x40BB5F: plugin_dispatch_values (plugin.c:1569)
==23779==    by 0x40BD65: plugin_dispatch_values_secure (plugin.c:1602)
==23779==    by 0x65FA182: parse_packet (network.c:408)
==23779==    by 0x65F9F48: parse_packet (network.c:1036)
==23779==    by 0x65FA3B0: dispatch_thread (network.c:2224)
==23779==    by 0x503C7E0: start_thread (in /lib64/libpthread-2.12.so)
==23779== 
==23779== LEAK SUMMARY:
==23779==    definitely lost: 5,253,109 bytes in 39,705 blocks
==23779==    indirectly lost: 384 bytes in 3 blocks
==23779==      possibly lost: 128 bytes in 1 blocks
==23779==    still reachable: 179,200 bytes in 1,632 blocks
==23779==         suppressed: 0 bytes in 0 blocks
==23779== Reachable blocks (those to which a pointer was found) are not shown.
==23779== To see them, rerun with: --leak-check=full --show-reachable=yes
==23779== 
==23779== For counts of detected and suppressed errors, rerun with: -v
==23779== ERROR SUMMARY: 18 errors from 18 contexts (suppressed: 6 from 6)

Note the following still remain 

==3965== HEAP SUMMARY:
==3965==     in use at exit: 179,312 bytes in 1,634 blocks
==3965==   total heap usage: 154,262 allocs, 152,628 frees, 10,428,444 bytes allocated
==3965== 
==3965== 48 bytes in 1 blocks are definitely lost in loss record 49 of 97
==3965==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==3965==    by 0x4084BB: cf_read_generic (configfile.c:693)
==3965==    by 0x408E1A: cf_read (configfile.c:930)
==3965==    by 0x405624: main (collectd.c:477)
==3965== 
==3965== 64 bytes in 1 blocks are definitely lost in loss record 55 of 97
==3965==    at 0x4C26FDE: malloc (vg_replace_malloc.c:236)
==3965==    by 0x65FB109: fbh_create (utils_fbhash.c:207)
==3965==    by 0x65F79E2: sockent_open (network.c:1977)
==3965==    by 0x65F842A: network_config (network.c:2955)
==3965==    by 0x40903C: cf_read (configfile.c:361)
==3965==    by 0x405624: main (collectd.c:477)
==3965== 
==3965== LEAK SUMMARY:
==3965==    definitely lost: 112 bytes in 2 blocks
==3965==    indirectly lost: 0 bytes in 0 blocks
==3965==      possibly lost: 0 bytes in 0 blocks
==3965==    still reachable: 179,200 bytes in 1,632 blocks
==3965==         suppressed: 0 bytes in 0 blocks
==3965== Reachable blocks (those to which a pointer was found) are not shown.
==3965== To see them, rerun with: --leak-check=full --show-reachable=yes
==3965== 
==3965== For counts of detected and suppressed errors, rerun with: -v
==3965== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 6 from 6)
