### PR TITLE
Proposal fix for large "MaxPacketSize" use.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -2735,7 +2735,7 @@ static int network_write (const data_set_t *ds, const value_list_t *vl,
 		ERROR ("network plugin: Unable to append to the "
 				"buffer for some weird reason");
 	}
-	else if ((network_config_packet_size - send_buffer_fill) < 15)
+	else if (send_buffer_fill >= 1452 - 15)
 	{
 		flush_buffer ();
 	}


### PR DESCRIPTION
When we use a "MaxPacketSize" over two thousand of octets (to pass huge
message in notification for example), buffer may not be flushed for a
while.
By flushing buffer when there is about 1400 octets, we're sure there is
no data too longer in.
