### PR TITLE
MongoDB rewrite

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2163,10 +2163,10 @@ AC_ARG_WITH(libmongoc, [AS_HELP_STRING([--with-libmongoc@<:@=PREFIX@:>@], [Path 
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
+SAVE_LIBS="$LIBS"
 
 CPPFLAGS="$CPPFLAGS $LIBMONGOC_CPPFLAGS"
 LDFLAGS="$LDFLAGS $LIBMONGOC_LDFLAGS"
-
 if test "x$with_libmongoc" = "xyes"
 then
 	if test "x$LIBMONGOC_CPPFLAGS" != "x"
@@ -2192,8 +2192,11 @@ then
 	AC_CHECK_LIB(mongoc, mongo_run_command,
 	[with_libmongoc="yes"],
 	[with_libmongoc="no (symbol 'mongo_run_command' not found)"])
+	LIBS="$LIBS -lmongoc"
+	AC_CHECK_FUNCS(bson_iterator_subobject_init)
 fi
 
+LIBS="$SAVE_LIBS"
 CPPFLAGS="$SAVE_CPPFLAGS"
 LDFLAGS="$SAVE_LDFLAGS"
 

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -35,6 +35,10 @@
 #define MC_MONGO_DEF_HOST "127.0.0.1"
 #define MC_MONGO_DEF_DB "admin"
 
+#ifndef bson_iterator_subobject_init
+#define bson_iterator_subobject_init(iter, subiter, copy) bson_iterator_subobject(iter, subiter)
+#endif /* ifndef bson_iterator_subobject_init */
+
 static char *mc_user     = NULL;
 static char *mc_password = NULL;
 static char *mc_db       = NULL;

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -2,6 +2,7 @@
  * collectd - src/mongo.c
  * Copyright (C) 2010 Ryan Cox
  * Copyright (C) 2012 Florian Forster
+ * Copyright (C) 2013 John (J5) Palmieri
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -19,6 +20,7 @@
  * Authors:
  *   Ryan Cox <ryan.a.cox at gmail.com>
  *   Florian Forster <octo at collectd.org>
+ *   John (J5) Palmieri <j5 at stackdriver.com>
  **/
 
 #include "collectd.h"

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -37,6 +37,9 @@
 
 #ifndef bson_iterator_subobject_init
 #define bson_iterator_subobject_init(iter, subiter, copy) bson_iterator_subobject(iter, subiter)
+#define _bson_subobject_destroy(obj) /* noop */
+#else
+#define _bson_subobject_destroy(obj) bson_destroy(obj)
 #endif /* ifndef bson_iterator_subobject_init */
 
 static char *mc_user     = NULL;
@@ -328,6 +331,7 @@ static int handle_index_counters (bson_iterator *iter) /* {{{ */
 
     bson_iterator_subobject_init (iter, &subobj, 0);
     status = handle_btree (&subobj);
+    _bson_subobject_destroy(&subobj);
 
     return (status);
 } /* }}} int handle_index_counters */

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -24,6 +24,7 @@
 #include "collectd.h"
 #include "common.h"
 #include "plugin.h"
+#include "utils_llist.h"
 
 #if HAVE_STDINT_H
 # define MONGO_HAVE_STDINT 1
@@ -31,25 +32,55 @@
 # define MONGO_USE_LONG_LONG_INT 1
 #endif
 #include <mongo.h>
+#include <bson.h>
+#include <libmongoc/src/env.h>
 
 #define MC_MONGO_DEF_HOST "127.0.0.1"
-#define MC_MONGO_DEF_DB "admin"
 
-#ifndef bson_iterator_subobject_init
-#define bson_iterator_subobject_init(iter, subiter, copy) bson_iterator_subobject(iter, subiter)
-#define _bson_subobject_destroy(obj) /* noop */
-#else
-#define _bson_subobject_destroy(obj) bson_destroy(obj)
-#endif /* ifndef bson_iterator_subobject_init */
+/* FIXME: use autoconf to determine if bson_iterator_subobject_init or
+          the older bson_iterator_subobject should be used.  Right now
+          you need to use the unreleased mongo c driver out of git.
+*/
 
-static char *mc_user     = NULL;
-static char *mc_password = NULL;
-static char *mc_db       = NULL;
-static char *mc_host     = NULL;
-static int   mc_port     = 0;
+# define _bson_subobject_destroy(obj) bson_destroy(obj)
 
-static mongo mc_connection;
-static _Bool mc_have_connection = 0;
+/* TODO: Flesh this all out a bit more for use with non-auto-discover
+ *       setups
+ */
+struct mongo_db_s /* {{{ */
+{
+    char *name;
+    char *user;
+    char *password;
+    mongo connection;
+
+    _Bool read_from_secondary;
+};
+
+typedef struct mongo_db_s mongo_db_t; /* }}} */
+
+struct mongo_config_s /* {{{ */
+{
+    char *user;
+    char *password;
+    char *host;
+    char *name;
+    int   port;
+
+    char *set_name;
+    mongo connection;
+
+    _Bool is_primary;
+    _Bool run_dbstats;
+    _Bool auto_discover;
+
+    char *secondary_query_host;
+
+    llist_t *db_llist;
+};
+typedef struct mongo_config_s mongo_config_t; /* }}} */
+
+mongo_config_t *mc = NULL;
 
 static const char *config_keys[] = {
     "User",
@@ -60,70 +91,82 @@ static const char *config_keys[] = {
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
-static int mc_connect() { /* {{{ */
+static void mc_config_set (char **dest, const char *src ) /* {{{ */
+{
+    sfree(*dest);
+    *dest = strdup (src);
+} /* }}} void mc_config_set */
+
+/*
+ * This should be upstreamed into the mongo-c-driver
+ *   connect and authenticate while returning the output of is_master command
+ */
+static MONGO_EXPORT int _mongo_client_complex (mongo *conn , const char *host, int port, const char *user, const char *pass, bson *is_master_out) { /* {{{ */
     int status;
 
-    if (mc_have_connection) {
-        // reconnect if needed
-        status = mongo_check_connection(&mc_connection);
-        if (status == MONGO_ERROR) {
-            status = mongo_reconnect(&mc_connection);
-            if (status != MONGO_OK)
-            {
-                ERROR ("mongo plugin: Reonnecting to %s:%i failed: %s",
-                        (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-                        (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
-                        mc_connection.errstr);
-                return (-1);
-            }
-        }
+    mongo_init( conn );
 
-        if (mc_user!=NULL && mc_password!=NULL) {
-        status = mongo_cmd_authenticate (&mc_connection, mc_db, mc_user, mc_password);
-            if (status != MONGO_OK)
-            {
-                ERROR ("mongo plugin: Authenticating to %s:%i failed: %s",
-                        (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-                        (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
-                        mc_connection.errstr);
-                return (-1);
-            }
-        }
-        return (0);
-    }
+    conn->primary = (mongo_host_port*) bson_malloc (sizeof (mongo_host_port));
+    snprintf( conn->primary->host, MAXHOSTNAMELEN, "%s", host);
+    conn->primary->port = port;
+    conn->primary->next = NULL;
 
-    mongo_init (&mc_connection);
+    if( mongo_env_socket_connect (conn, host, port) != MONGO_OK )
+        return MONGO_ERROR;
 
-    status = mongo_client (&mc_connection,
-            (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-            (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT);
-    if (status != MONGO_OK)
-    {
-        ERROR ("mongo plugin: Connecting to %s:%i failed: %s",
-                (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-                (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
-                mc_connection.errstr);
-        return (-1);
-    }
-
-    if (mc_user!=NULL && mc_password!=NULL) {
-        status = mongo_cmd_authenticate (&mc_connection, mc_db, mc_user, mc_password);
+    if (user!=NULL && pass!=NULL) {
+        status = mongo_cmd_authenticate (conn, "admin", user, pass);
         if (status != MONGO_OK)
         {
             ERROR ("mongo plugin: Authenticating to %s:%i failed: %s",
-                    (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-                    (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
-                    mc_connection.errstr);
+                    host,
+                    port,
+                    conn->errstr);
             return (-1);
         }
     }
 
-    mc_have_connection = 1;
+    if (is_master_out != NULL)
+        mongo_cmd_ismaster (conn, is_master_out);
+
+    return MONGO_OK;
+} /* }}} int _mongo_client_complex */
+
+/*
+ *  Check connection and connect if needed
+ */
+static int mc_connect (mongo *conn, const char *host, int port, const char *user, const char *pass, bson *is_master_out) { /* {{{ */
+    int status;
+
+    status = mongo_check_connection(conn);
+    if (status == MONGO_ERROR) {
+        mongo_disconnect(conn);
+    } else {
+        // we are still connected
+        return MONGO_OK;
+    }
+
+    status = _mongo_client_complex (conn,
+            (host != NULL) ? host : MC_MONGO_DEF_HOST,
+            (port > 0) ? port : MONGO_DEFAULT_PORT,
+            user,
+            pass,
+            is_master_out);
+    if (status != MONGO_OK)
+    {
+        ERROR ("mongo plugin: Connecting to %s:%i failed: %s",
+                (host != NULL) ? host : MC_MONGO_DEF_HOST,
+                (port > 0) ? port : MONGO_DEFAULT_PORT,
+                conn->errstr);
+        return (-1);
+    }
+
     return (0);
 } /* }}} int mc_connect */
 
 static void submit (const char *type, const char *instance, /* {{{ */
-        value_t *values, size_t values_len)
+        value_t *values, size_t values_len,
+        mongo_db_t *db)
 {
     value_list_t v = VALUE_LIST_INIT;
 
@@ -132,7 +175,9 @@ static void submit (const char *type, const char *instance, /* {{{ */
 
     sstrncpy (v.host, hostname_g, sizeof(v.host));
     sstrncpy (v.plugin, "mongodb", sizeof(v.plugin));
-    ssnprintf (v.plugin_instance, sizeof (v.plugin_instance), "%i", mc_port);
+    if (db != NULL) {
+        ssnprintf (v.plugin_instance, sizeof (v.plugin_instance), "%s", db->name);
+    }
     sstrncpy (v.type, type, sizeof(v.type));
 
     if (instance != NULL)
@@ -142,12 +187,12 @@ static void submit (const char *type, const char *instance, /* {{{ */
 } /* }}} void submit */
 
 static void submit_gauge (const char *type, const char *instance, /* {{{ */
-        gauge_t gauge)
+        gauge_t gauge, mongo_db_t *db)
 {
     value_t v;
 
     v.gauge = gauge;
-    submit(type, instance, &v, /* values_len = */ 1);
+    submit(type, instance, &v, /* values_len = */ 1, db);
 } /* }}} void submit_gauge */
 
 static void submit_derive (const char *type, const char *instance, /* {{{ */
@@ -156,7 +201,7 @@ static void submit_derive (const char *type, const char *instance, /* {{{ */
     value_t v;
 
     v.derive = derive;
-    submit(type, instance, &v, /* values_len = */ 1);
+    submit(type, instance, &v, /* values_len = */ 1, NULL);
 } /* }}} void submit_derive */
 
 static int handle_field (bson *obj, const char *field, /* {{{ */
@@ -228,7 +273,7 @@ static int handle_mem (bson_iterator *iter) /* {{{ */
     /* All values are in MByte */
     value *= 1048576.0;
 
-    submit_gauge ("memory", key, value);
+    submit_gauge ("memory", key, value, NULL);
     return (0);
 } /* }}} int handle_mem */
 
@@ -251,7 +296,7 @@ static int handle_connections (bson_iterator *iter) /* {{{ */
 
     value = (gauge_t) bson_iterator_double (iter);
 
-    submit_gauge ("current_connections", NULL, value);
+    submit_gauge ("current_connections", NULL, value, NULL);
     return (0);
 } /* }}} int handle_connections */
 
@@ -303,9 +348,9 @@ static int handle_btree (const bson *obj) /* {{{ */
         value = (gauge_t) bson_iterator_double (&i);
 
         if (strcmp ("hits", key) == 0)
-            submit_gauge ("cache_result", "hit", value);
+            submit_gauge ("cache_result", "hit", value, NULL);
         else if (strcmp ("misses", key) != 0)
-            submit_gauge ("cache_result", "miss", value);
+            submit_gauge ("cache_result", "miss", value, NULL);
     }
 
     return (0);
@@ -341,14 +386,14 @@ static int query_server_status (void) /* {{{ */
     bson result;
     int status;
 
-    status = mongo_simple_int_command (&mc_connection,
-            (mc_db != NULL) ? mc_db : MC_MONGO_DEF_DB,
+    status = mongo_simple_int_command (&(mc->connection),
+            "admin",
             /* cmd = */ "serverStatus", /* arg = */ 1,
             &result);
     if (status != MONGO_OK)
     {
         ERROR ("mongodb plugin: Calling {\"serverStatus\": 1} failed: %s",
-                mc_connection.errstr);
+                mc->connection.errstr);
         return (-1);
     }
 
@@ -362,7 +407,7 @@ static int query_server_status (void) /* {{{ */
     return (0);
 } /* }}} int query_server_status */
 
-static int handle_dbstats (const bson *obj) /* {{{ */
+static int handle_dbstats (mongo_db_t *db, const bson *obj) /* {{{ */
 {
     bson_iterator i;
 
@@ -385,91 +430,243 @@ static int handle_dbstats (const bson *obj) /* {{{ */
 
         /* counts */
         if (strcmp ("collections", key) == 0)
-            submit_gauge ("gauge", "collections", value);
+            submit_gauge ("gauge", "collections", value, db);
         else if (strcmp ("objects", key) == 0)
-            submit_gauge ("gauge", "objects", value);
+            submit_gauge ("gauge", "objects", value, db);
         else if (strcmp ("numExtents", key) == 0)
-            submit_gauge ("gauge", "num_extents", value);
+            submit_gauge ("gauge", "num_extents", value, db);
         else if (strcmp ("indexes", key) == 0)
-            submit_gauge ("gauge", "indexes", value);
+            submit_gauge ("gauge", "indexes", value, db);
         /* sizes */
         else if (strcmp ("dataSize", key) == 0)
-            submit_gauge ("bytes", "data", value);
+            submit_gauge ("bytes", "data", value, db);
         else if (strcmp ("storageSize", key) == 0)
-            submit_gauge ("bytes", "storage", value);
+            submit_gauge ("bytes", "storage", value, db);
         else if (strcmp ("indexSize", key) == 0)
-            submit_gauge ("bytes", "index", value);
+            submit_gauge ("bytes", "index", value, db);
     }
 
     return (0);
 } /* }}} int handle_dbstats */
 
-static int query_dbstats (void) /* {{{ */
+static int mc_db_stats_read_cb (user_data_t *ud) /* {{{ */
 {
     bson result;
+    bson b;
     int status;
+    mongo_db_t *db = (mongo_db_t *) ud;
 
-    /* TODO:
-     *
-     *  change this to raw runCommand
-     *       db.runCommand( { dbstats : 1 } );
-     *       succeeds but is getting back all zeros !?!
-     *  modify bson_print to print type 18
-     *  repro problem w/o db name - show dbs doesn't work again
-     *  why does db.admin.dbstats() work fine in shell?
-     *  implement retries ? noticed that if db is unavailable, collectd dies
-     */
-
-    memset (&result, 0, sizeof (result));
-    status = mongo_simple_int_command (&mc_connection,
-            (mc_db != NULL) ? mc_db : MC_MONGO_DEF_DB,
-            /* cmd = */ "dbstats", /* arg = */ 1,
-            &result);
-    if (status != MONGO_OK)
-    {
-        ERROR ("mongodb plugin: Calling {\"dbstats\": 1} failed: %s",
-                mc_connection.errstr);
+    if (mc_connect(&(db->connection),
+                        mc->host,
+                        mc->port,
+                        (db->user != NULL) ? db->user : mc->user,
+                        (db->password != NULL) ? db->password : mc->password,
+                        NULL) != 0) {
         return (-1);
     }
 
-    handle_dbstats (&result);
+    bson_init (&result);
+    bson_init (&b);
+    bson_append_int (&b, "dbStats", 1);
+    bson_append_int (&b, "scale", 1);
+    bson_finish (&b);
+    status = mongo_run_command (&(db->connection), db->name, &b, &result);
+    bson_destroy (&b);
+    if (status != MONGO_OK)
+    {
+        ERROR ("mongodb plugin: Calling {\"dbstats\": 1} failed: %s",
+                mc->connection.errstr);
+        return (-1);
+    }
+
+    handle_dbstats (db, &result);
 
     bson_destroy (&result);
     return (0);
 } /* }}} int query_dbstats */
 
-static int mc_read(void) /* {{{ */
+static void mc_unregister_and_free_ghost_dbs(llist_t *ghost_dbs, _Bool free_list) {
+    llentry_t *e_this;
+    llentry_t *e_next;
+
+    if (ghost_dbs == NULL)
+        return;
+
+    for (e_this = llist_head(ghost_dbs); e_this != NULL; e_this = e_next)
+    {
+        e_next = e_this->next;
+        plugin_unregister_read (e_this->key);
+        llentry_destroy (e_this);
+    }
+
+    if (free_list)
+        free (ghost_dbs);
+}
+
+static void free_db_userdata(void *data) {
+    mongo_db_t *db = (mongo_db_t *) data;
+    sfree (db->name);
+    sfree (db->user);
+    sfree (db->password);
+    mongo_destroy (&(db->connection));
+}
+
+static int setup_dbs(void) /* {{{ */
 {
-    if (mc_connect() != 0) {
+    bson out;
+    bson_iterator it;
+    llist_t *active_db_llist = llist_create ();
+    llist_t *old_db_llist = mc->db_llist;
+    mongo_db_t *db;
+
+    if (!mongo_simple_int_command( &(mc->connection), "admin", "listDatabases", 1, &out ) != MONGO_OK )
+        return MONGO_ERROR;
+
+    bson_iterator_init (&it, &out);
+    while (bson_iterator_next (&it)) {
+        llentry_t *entry;
+        bson sub;
+        const char *db_name;
+        char cb_name[DATA_MAX_NAME_LEN];
+        bson_iterator sub_it;
+
+        bson_iterator_subobject_init (&it, &sub, 0);
+        if (bson_find(&sub_it, &sub, "name")) {
+            db_name = bson_iterator_string (&sub_it);
+        } else {
+            // shouldn't happen
+            continue;
+        }
+
+        ssnprintf (cb_name, sizeof (cb_name), "mongo-%s", db_name);
+        entry = llist_search (old_db_llist, cb_name);
+
+        if (entry == NULL) {
+            user_data_t ud;
+            char *new_cb_name = strdup (cb_name);
+            if (new_cb_name == NULL) {
+                 ERROR ("mongodb plugin: OOM configuring dbs");
+                 return MONGO_ERROR;
+            }
+
+            entry = llentry_create (new_cb_name, NULL);
+            if (entry == NULL) {
+                ERROR ("mongodb plugin: OOM configuring dbs");
+                return MONGO_ERROR;
+            }
+
+            DEBUG ("mongodb plugin: Registering new read callback: %s",
+                   cb_name);
+
+            db = malloc (sizeof (mongo_db_t));
+            if (db == NULL) {
+                ERROR ("mongodb plugin: OOM configuring dbs");
+                return MONGO_ERROR;
+            }
+
+            memset (db, 0, sizeof (mongo_db_t));
+            db->name = strdup (db_name);
+            if (db->name == NULL) {
+                ERROR ("mongodb plugin: OOM configuring dbs");
+                return MONGO_ERROR;
+            }
+
+            memset (&ud, 0, sizeof (ud));
+            ud.data = (void *) db;
+            ud.free_func = free_db_userdata;
+
+            plugin_register_complex_read (NULL, cb_name, mc_db_stats_read_cb, NULL, &ud);
+        } else {
+            llist_remove (old_db_llist, entry);
+            llist_append (active_db_llist, entry);
+        }
+        _bson_subobject_destroy (&sub);
+    }
+    bson_destroy (&out);
+
+    mc->db_llist = active_db_llist;
+
+    /* clean up any dbs that were removed */
+    mc_unregister_and_free_ghost_dbs (old_db_llist, 1);
+    return (0);
+}
+/* }}} setup_dbs */
+
+static int mc_setup_read(void) /* {{{ */
+{
+    bson is_master_out;
+    bson_iterator it;
+    int max_bson_size = MONGO_DEFAULT_MAX_BSON_SIZE;
+
+    if (mc_connect(&(mc->connection), mc->host, mc->port, mc->user, mc->password, &is_master_out) != 0) {
         return (-1);
     }
+
+    if( bson_find( &it, &is_master_out, "ismaster" ) )
+        mc->is_primary = bson_iterator_bool( &it );
+    if( bson_find( &it, &is_master_out, "maxBsonObjectSize" ) )
+        max_bson_size = bson_iterator_int( &it );
+    if( bson_find( &it, &is_master_out, "setName" ) )
+        mc_config_set(&(mc->set_name), bson_iterator_string( &it ));
+    mc->connection.max_bson_size = max_bson_size;
+
+    bson_destroy( &is_master_out );
+
+    /* Only the primary node sends back stats for now
+     * though it may query a secondary node for queries that are
+     * intensive
+     */
+    if (!mc->is_primary) {
+        /* unregister any db reads */
+        mc_unregister_and_free_ghost_dbs (mc->db_llist, 0);
+        return (0);
+    }
+
+    if (setup_dbs () != 0)
+        return (-1);
 
     if (query_server_status () != 0)
         return (-1);
 
-    if (query_dbstats () != 0)
-        return (-1);
-
     return (0);
-} /* }}} int mc_read */
+} /* }}} int mc_setup_read */
 
-static void mc_config_set (char **dest, const char *src ) /* {{{ */
-{
-    sfree(*dest);
-    *dest = strdup (src);
-} /* }}} void mc_config_set */
+static int mc_init_config_struct (void) {
+    if (mc == NULL) {
+        mc = (mongo_config_t *) malloc (sizeof(mongo_config_t));
+        if (mc == NULL) {
+            ERROR ("mongodb plugin: malloc failed for configuration data.");
+            return (-1);
+        }
+        memset (mc, 0, sizeof (mongo_config_t));
+        /* autodiscover on by default */
+        mc->auto_discover = 1;
+        mc->db_llist = llist_create();
+        if (mc->db_llist == NULL) {
+            ERROR ("OOM trying to allocate the db list");
+            return (-1);
+        }
+
+        mongo_init(&(mc->connection));
+    }
+    return 0;
+}
 
 static int mc_config (const char *key, const char *value) /* {{{ */
 {
+
+    if (mc_init_config_struct() != 0)
+        return -1;
+
     if (strcasecmp("Host", key) == 0)
-        mc_config_set(&mc_host,value);
+        mc_config_set(&(mc->host),value);
     else if (strcasecmp("Port", key) == 0)
     {
         int tmp;
 
         tmp = service_name_to_port_number (value);
         if (tmp > 0)
-            mc_port = tmp;
+            mc->port = tmp;
         else
         {
             ERROR("mongodb plugin: failed to parse Port value: %s", value);
@@ -477,11 +674,9 @@ static int mc_config (const char *key, const char *value) /* {{{ */
         }
     }
     else if(strcasecmp("User", key) == 0)
-        mc_config_set(&mc_user,value);
+        mc_config_set(&mc->user, value);
     else if(strcasecmp("Password", key) == 0)
-        mc_config_set(&mc_password,value);
-    else if(strcasecmp("Database", key) == 0)
-        mc_config_set(&mc_db,value);
+        mc_config_set(&mc->password, value);
     else
     {
         ERROR ("mongodb plugin: Unknown config option: %s", key);
@@ -493,16 +688,16 @@ static int mc_config (const char *key, const char *value) /* {{{ */
 
 static int mc_shutdown(void) /* {{{ */
 {
-    if (mc_have_connection) {
-        mongo_destroy (&mc_connection);
-        mc_have_connection = 0;
-    }
+    mongo_destroy (&(mc->connection));
 
-    sfree (mc_user);
-    sfree (mc_password);
-    sfree (mc_db);
-    sfree (mc_host);
+    sfree (mc->user);
+    sfree (mc->password);
+    sfree (mc->host);
 
+    llist_destroy(mc->db_llist);
+
+
+    free (mc);
     return (0);
 } /* }}} int mc_shutdown */
 
@@ -510,7 +705,9 @@ void module_register(void)
 {
     plugin_register_config ("mongodb", mc_config,
             config_keys, config_keys_num);
-    plugin_register_read ("mongodb", mc_read);
+
+    /* the setup read checks if we are a master node and sets up database reads accordingly */
+    plugin_register_read ("mongodb", mc_setup_read);
     plugin_register_shutdown ("mongodb", mc_shutdown);
 }
 

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -55,8 +55,6 @@ struct mongo_db_s /* {{{ */
     char *user;
     char *password;
     mongo connection;
-
-    _Bool read_from_secondary;
 };
 
 typedef struct mongo_db_s mongo_db_t; /* }}} */
@@ -76,7 +74,9 @@ struct mongo_config_s /* {{{ */
     _Bool run_dbstats;
     _Bool auto_discover;
 
+    _Bool allow_secondary_query;
     char *secondary_query_host;
+    int   secondary_query_port;
 
     llist_t *db_llist;
 };
@@ -89,7 +89,8 @@ static const char *config_keys[] = {
     "Password",
     "Database",
     "Host",
-    "Port"
+    "Port",
+    "AllowSecondaryQuery"
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
@@ -459,13 +460,20 @@ static int mc_db_stats_read_cb (user_data_t *ud) /* {{{ */
     bson b;
     int status;
     mongo_db_t *db = (mongo_db_t *) ud->data;
+    const char *host = mc->host;
+    int port = mc->port;
+
+    if (mc->allow_secondary_query && mc->secondary_query_host != NULL) {
+        host = mc->secondary_query_host;
+        port = mc->secondary_query_port;
+    }
 
     if (mc_connect(&(db->connection),
-                        mc->host,
-                        mc->port,
-                        (db->user != NULL) ? db->user : mc->user,
-                        (db->password != NULL) ? db->password : mc->password,
-                        NULL) != 0) {
+                   host,
+                   port,
+                   (db->user != NULL) ? db->user : mc->user,
+                   (db->password != NULL) ? db->password : mc->password,
+                   NULL) != 0) {
         return (-1);
     }
 
@@ -513,6 +521,7 @@ static void free_db_userdata(void *data) {
     sfree (db->user);
     sfree (db->password);
     mongo_destroy (&(db->connection));
+    free (db);
 }
 
 static int setup_dbs(void) /* {{{ */
@@ -599,6 +608,54 @@ oom:
 }
 /* }}} setup_dbs */
 
+static void mc_split_host_port (const char *full_host, char **host_in, int *port_in) /* {{{ */
+{
+    char *delimit_c;
+    delimit_c = strrchr(full_host, ':');
+    if (delimit_c == NULL) {
+        /* this is ulikely but use a default port if no port is given */
+        *port_in = 27017;
+        *host_in = strdup (full_host);
+    } else {
+        /* grab the port from the right side of the delimiter */
+        sscanf (delimit_c, ":%d", port_in);
+
+        /* dup the string up to the delimit pointer */
+        *host_in = strndup (full_host, (size_t)(delimit_c - full_host));
+    }
+} /* }}} void mc_split_host_port */
+
+static void mc_config_secondary (bson *is_master) /* {{{ */
+{
+    bson_iterator it;
+    bson_iterator hosts_it;
+    const char *primary;
+    mc->secondary_query_host = NULL;
+
+
+    if (bson_find (&it, is_master, "primary")) {
+        primary = bson_iterator_string (&it);
+    } else {
+        WARNING("mongodb plugin: failed to find the primary db from call to isMaster");
+        return;
+    }
+
+    /* grab the first address that is not the primary */
+    if (bson_find (&it, is_master, "hosts")) {
+       bson_iterator_subiterator (&it, &hosts_it);
+       while (bson_iterator_next (&hosts_it)) {
+           const char *host;
+           host = bson_iterator_string (&hosts_it);
+           if (strcmp (host, primary) != 0) {
+               mc_split_host_port (host, &mc->secondary_query_host, &mc->secondary_query_port);
+               break;
+           }
+       }
+    } else {
+        WARNING("mongodb plugin: failed to find list of hosts from call to isMaster");
+    }
+} /* }}} void mc_config_secondary */
+
 static int mc_setup_read(void) /* {{{ */
 {
     bson is_master_out;
@@ -617,7 +674,11 @@ static int mc_setup_read(void) /* {{{ */
         mc_config_set(&(mc->set_name), bson_iterator_string( &it ));
     mc->connection.max_bson_size = max_bson_size;
 
-    bson_destroy( &is_master_out );
+    if (mc->allow_secondary_query) {
+        mc_config_secondary (&is_master_out);
+    }
+
+    bson_destroy (&is_master_out);
 
     /* Only the primary node sends back stats for now
      * though it may query a secondary node for queries that are
@@ -680,10 +741,15 @@ static int mc_config (const char *key, const char *value) /* {{{ */
             return (-1);
         }
     }
-    else if(strcasecmp("User", key) == 0)
+    else if (strcasecmp("User", key) == 0)
         mc_config_set(&mc->user, value);
-    else if(strcasecmp("Password", key) == 0)
+    else if (strcasecmp("Password", key) == 0)
         mc_config_set(&mc->password, value);
+    else if (strcasecmp("AllowSecondaryQuery", key) == 0)
+        if (strcasecmp("true", value) == 0 || strcasecmp("1", value) == 0)
+            mc->allow_secondary_query = 1;
+        else
+            mc->allow_secondary_query = 0;
     else
     {
         ERROR ("mongodb plugin: Unknown config option: %s", key);
@@ -700,6 +766,7 @@ static int mc_shutdown(void) /* {{{ */
     sfree (mc->user);
     sfree (mc->password);
     sfree (mc->host);
+    sfree (mc->secondary_query_host);
 
     llist_destroy(mc->db_llist);
 

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -35,16 +35,17 @@
 #endif
 #include <mongo.h>
 #include <bson.h>
-#include <libmongoc/src/env.h>
+#include <env.h>
 
 #define MC_MONGO_DEF_HOST "127.0.0.1"
 
-/* FIXME: use autoconf to determine if bson_iterator_subobject_init or
-          the older bson_iterator_subobject should be used.  Right now
-          you need to use the unreleased mongo c driver out of git.
-*/
-
+#if HAVE_BSON_ITERATOR_SUBOBJECT_INIT /* mongo-c-driver git HEAD */
 # define _bson_subobject_destroy(obj) bson_destroy(obj)
+#else /* mongo-c-driver 0.7.x */
+/* noop */
+# define _bson_subobject_destroy(obj)
+# define bson_iterator_subobject_init(iter,obj,copy) bson_iterator_subobject(iter,obj)
+#endif
 
 /* TODO: Flesh this all out a bit more for use with non-auto-discover
  *       setups

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -326,7 +326,7 @@ static int handle_lock (bson_iterator *iter) /* {{{ */
      * milliseconds (ms). */
     value = value / 1000;
 
-    submit_derive ("total_time_in_ms", "lock_held", value);
+    submit_derive ("total_time_in_ms", "global_lock_held", value);
     return (0);
 } /* }}} int handle_lock */
 

--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -53,6 +53,68 @@ static const char *config_keys[] = {
 };
 static int config_keys_num = STATIC_ARRAY_SIZE (config_keys);
 
+static int mc_connect() { /* {{{ */
+    int status;
+
+    if (mc_have_connection) {
+        // reconnect if needed
+        status = mongo_check_connection(&mc_connection);
+        if (status == MONGO_ERROR) {
+            status = mongo_reconnect(&mc_connection);
+            if (status != MONGO_OK)
+            {
+                ERROR ("mongo plugin: Reonnecting to %s:%i failed: %s",
+                        (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
+                        (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
+                        mc_connection.errstr);
+                return (-1);
+            }
+        }
+
+        if (mc_user!=NULL && mc_password!=NULL) {
+        status = mongo_cmd_authenticate (&mc_connection, mc_db, mc_user, mc_password);
+            if (status != MONGO_OK)
+            {
+                ERROR ("mongo plugin: Authenticating to %s:%i failed: %s",
+                        (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
+                        (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
+                        mc_connection.errstr);
+                return (-1);
+            }
+        }
+        return (0);
+    }
+
+    mongo_init (&mc_connection);
+
+    status = mongo_client (&mc_connection,
+            (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
+            (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT);
+    if (status != MONGO_OK)
+    {
+        ERROR ("mongo plugin: Connecting to %s:%i failed: %s",
+                (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
+                (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
+                mc_connection.errstr);
+        return (-1);
+    }
+
+    if (mc_user!=NULL && mc_password!=NULL) {
+        status = mongo_cmd_authenticate (&mc_connection, mc_db, mc_user, mc_password);
+        if (status != MONGO_OK)
+        {
+            ERROR ("mongo plugin: Authenticating to %s:%i failed: %s",
+                    (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
+                    (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
+                    mc_connection.errstr);
+            return (-1);
+        }
+    }
+
+    mc_have_connection = 1;
+    return (0);
+} /* }}} int mc_connect */
+
 static void submit (const char *type, const char *instance, /* {{{ */
         value_t *values, size_t values_len)
 {
@@ -260,9 +322,8 @@ static int handle_index_counters (bson_iterator *iter) /* {{{ */
     if (strcmp ("btree", key) != 0)
         return (0);
 
-    bson_iterator_subobject (iter, &subobj);
+    bson_iterator_subobject_init (iter, &subobj, 0);
     status = handle_btree (&subobj);
-    bson_destroy (&subobj);
 
     return (status);
 } /* }}} int handle_index_counters */
@@ -371,6 +432,10 @@ static int query_dbstats (void) /* {{{ */
 
 static int mc_read(void) /* {{{ */
 {
+    if (mc_connect() != 0) {
+        return (-1);
+    }
+
     if (query_server_status () != 0)
         return (-1);
 
@@ -418,35 +483,9 @@ static int mc_config (const char *key, const char *value) /* {{{ */
     return (0);
 } /* }}} int mc_config */
 
-static int mc_init (void) /* {{{ */
-{
-    int status;
-
-    if (mc_have_connection)
-        return (0);
-
-    mongo_init (&mc_connection);
-
-    status = mongo_connect (&mc_connection,
-            (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-            (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT);
-    if (status != MONGO_OK)
-    {
-        ERROR ("mongo plugin: Connecting to %s:%i failed: %s",
-                (mc_host != NULL) ? mc_host : MC_MONGO_DEF_HOST,
-                (mc_port > 0) ? mc_port : MONGO_DEFAULT_PORT,
-                mc_connection.errstr);
-        return (-1);
-    }
-
-    mc_have_connection = 1;
-    return (0);
-} /* }}} int mc_init */
-
 static int mc_shutdown(void) /* {{{ */
 {
     if (mc_have_connection) {
-        mongo_disconnect (&mc_connection);
         mongo_destroy (&mc_connection);
         mc_have_connection = 0;
     }
@@ -464,7 +503,6 @@ void module_register(void)
     plugin_register_config ("mongodb", mc_config,
             config_keys, config_keys_num);
     plugin_register_read ("mongodb", mc_read);
-    plugin_register_init ("mongodb", mc_init);
     plugin_register_shutdown ("mongodb", mc_shutdown);
 }
 


### PR DESCRIPTION
* requires mongo-c-driver 0.7.x or git HEAD
* Autodetects if it is running on the primary in a replica set
    * If primary it collects data
    * If secondary it checks each interval to see if it has become the primary
* AllowSecodaryQuery option added
    * for performance on servers with a lot of databases you can now have the plugin query a secondary server
    * this trades off consistency for conservation of resources depending on the latency of the replication (only done for dbStats calls which walks all the files in a database)